### PR TITLE
Add Dataverse upload workflow

### DIFF
--- a/.github/workflows/dataverse.yml
+++ b/.github/workflows/dataverse.yml
@@ -1,0 +1,24 @@
+name: Upload repository to Dataverse
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    name: Upload repository files
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send repository to Dataverse
+        uses: IQSS/dataverse-uploader@v1.7
+        with:
+          DATAVERSE_TOKEN: ${{ secrets.DATAVERSE_TOKEN }}
+          DATAVERSE_SERVER: https://dataverse.harvard.edu
+          DATAVERSE_DATASET_DOI: doi:10.7910/DVN/NH5D3J
+          DELETE: False
+          PUBLISH: False


### PR DESCRIPTION
Adds a GitHub Actions workflow that uploads repository contents to the Harvard Dataverse dataset doi:10.7910/DVN/NH5D3J using IQSS/dataverse-uploader@v1.7. The workflow runs manually or when a release is published, keeps DELETE and PUBLISH set to False, and reads the Dataverse API token from the DATAVERSE_TOKEN repository secret.