### PR TITLE
Publish Dataverse upload on main updates

### DIFF
--- a/.github/workflows/dataverse.yml
+++ b/.github/workflows/dataverse.yml
@@ -1,6 +1,8 @@
 name: Upload repository to Dataverse
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
   release:
     types: [published]
@@ -21,4 +23,4 @@ jobs:
           DATAVERSE_SERVER: https://dataverse.harvard.edu
           DATAVERSE_DATASET_DOI: doi:10.7910/DVN/NH5D3J
           DELETE: False
-          PUBLISH: False
+          PUBLISH: True


### PR DESCRIPTION
Updates the Dataverse upload workflow so it runs whenever main is updated and publishes the uploaded dataset version automatically.

Details:
- adds a push trigger for main
- keeps manual and release triggers
- changes PUBLISH to True
- leaves DELETE as False to avoid automatically deleting Dataverse-only files before every upload

Validation:
- parsed .github/workflows/dataverse.yml as YAML